### PR TITLE
Add android traceroute code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,3 @@
 ---
 BasedOnStyle: LLVM
-IndentWidth: 4
 ---

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ test/ooni/tcp_test
 test/protocols/dns
 test/protocols/http
 test/report/file
+test/traceroute/android
 test-driver
 *.log
 *.trs

--- a/include/ight/common/utils.hpp
+++ b/include/ight/common/utils.hpp
@@ -118,6 +118,12 @@ struct timeval *ight_timeval_init(struct timeval *, double);
 int ight_storage_init(struct sockaddr_storage *, socklen_t *, const char *,
                       const char *, const char *);
 
+int ight_storage_init(struct sockaddr_storage *, socklen_t *, int,
+                      const char *, const char *);
+
+int ight_storage_init(struct sockaddr_storage *, socklen_t *, int,
+                      const char *, int);
+
 evutil_socket_t ight_socket_create(int, int, int);
 
 int ight_socket_connect(evutil_socket_t, struct sockaddr_storage *, socklen_t);

--- a/include/ight/traceroute/android.hpp
+++ b/include/ight/traceroute/android.hpp
@@ -1,0 +1,134 @@
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ *
+ * =========================================================================
+ *
+ * Portions Copyright (c) 2015, Adriano Faggiani, Enrico Gregori,
+ * Luciano Lenzini, Valerio Luconi
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef IGHT_TRACEROUTE_ANDROID_HPP
+#define IGHT_TRACEROUTE_ANDROID_HPP
+
+/// Android implementation of traceroute interface
+
+// This is meant to run on Android but can run on all Linux systems
+#ifdef __linux__
+
+#include <ight/common/constraints.hpp>
+#include <ight/traceroute/interface.hpp>
+
+#include <event2/event.h>
+
+#include <time.h>
+
+struct sock_extended_err; // Forward declaration
+
+namespace ight {
+namespace traceroute {
+
+/// Traceroute prober for Android
+class AndroidProber : public ight::common::constraints::NonCopyable,
+                      public ight::common::constraints::NonMovable,
+                      public ProberInterface {
+
+public:
+  /// Constructor
+  /// \param use_ipv4 Whether to use IPv4
+  /// \param port The port to bind
+  /// \param evbase Event base to use (optional)
+  /// \throws Exception on error
+  AndroidProber(bool use_ipv4, int port,
+                event_base *evbase = ight_get_global_event_base());
+
+  /// Destructor
+  ~AndroidProber() { cleanup(); }
+
+  virtual void send_probe(std::string addr, int port, int ttl,
+                          std::string payload, double timeout) final;
+
+  virtual void on_result(std::function<void(ProbeResult)> cb) final {
+    result_cb_ = cb;
+  }
+
+  virtual void on_timeout(std::function<void()> cb) final { timeout_cb_ = cb; }
+
+  virtual void on_error(std::function<void(std::runtime_error)> cb) final {
+    error_cb_ = cb;
+  }
+
+private:
+  int sockfd_ = -1;              ///< socket descr
+  bool probe_pending_ = false;   ///< probe is pending
+  timespec start_time_{0, 0};    ///< start time
+  bool use_ipv4_ = true;         ///< using IPv4?
+  event_base *evbase_ = nullptr; ///< event base
+  event *evp_ = nullptr;         ///< event pointer
+
+  std::function<void(ProbeResult)> result_cb_;       ///< on result callback
+  std::function<void()> timeout_cb_;                 ///< on timeout callback
+  std::function<void(std::runtime_error)> error_cb_; ///< on error callback
+
+  /// Call this when you don't receive a response within timeout
+  void on_timeout() { probe_pending_ = false; }
+
+  /// Call this as soon as the socket is readable to get
+  /// the result ICMP error received by the socket and to
+  /// calculate *precisely* the RTT.
+  ProbeResult on_socket_readable();
+
+  /// Returns the source address of the error message.
+  /// \param use_ipv4 whether we are using IPv4
+  /// \param err socket error structure
+  /// \return source address of the error message
+  static std::string get_source_addr(bool use_ipv4, sock_extended_err *err);
+
+  /// Returns the Round Trip Time value in milliseconds
+  /// \param end ICMP reply arrival time
+  /// \param start UDP probe send time
+  /// \return RTT value in milliseconds
+  static double calculate_rtt(timespec end, timespec start);
+
+  /// Returns the Time to Live of the error message
+  /// \param data CMSG_DATA(cmsg)
+  /// \return ttl of the error message
+  static int get_ttl(void *data) { return *((int *)data); }
+
+  /// Callback invoked when the socket is readable
+  /// \param so Socket descriptor
+  /// \param event Event that occurred
+  /// \param ptr Opaque pointer to this class
+  static void event_callback(int so, short event, void *ptr);
+
+  /// Idempotent cleanup function
+  void cleanup();
+};
+
+} // namespace traceroute
+} // namespace ight
+#endif
+#endif

--- a/include/ight/traceroute/interface.hpp
+++ b/include/ight/traceroute/interface.hpp
@@ -1,0 +1,156 @@
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ *
+ * =========================================================================
+ *
+ * Portions Copyright (c) 2015, Adriano Faggiani, Enrico Gregori,
+ * Luciano Lenzini, Valerio Luconi
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef IGHT_TRACEROUTE_INTERFACE_HPP
+#define IGHT_TRACEROUTE_INTERFACE_HPP
+
+/// Interface of traceroute module
+
+#include <ight/common/poller.hpp>
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+// Forward declarations
+struct event_base;
+
+namespace ight {
+namespace traceroute {
+
+/// Meaning of a probe result
+enum class ProbeResultMeaning {
+  OTHER = 0,            ///< Another meaning
+  NO_ROUTE_TO_HOST = 1, ///< No route to host
+  ADDRESS_UNREACH = 2,  ///< E.g., link down
+  PROTO_NOT_IMPL = 3,   ///< UDP not implemented
+  DEST_REACHED = 4,     ///< Port is closed = dest. reached
+  TTL_EXCEEDED = 5,     ///< TTL is too small
+  ADMIN_FILTER = 6,     ///< E.g., firewall rule
+};
+
+/// Result of a traceroute probe
+class ProbeResult {
+public:
+  std::string interface_ip;      ///< Host that replied
+  int ttl = 0;                   ///< Response TTL
+  double rtt = 0.0;              ///< Round trip time
+  bool is_ipv4 = true;           ///< Are we using IPv4?
+  unsigned char icmp_type = 255; ///< Raw ICMP/ICMPv6 type
+  unsigned char icmp_code = 255; ///< Raw ICMP/ICMPv6 code
+  ssize_t recv_bytes = 0;        ///< Bytes recv'd
+
+  /// Maps ICMP/ICMPv6 type and code to a meaning
+  ProbeResultMeaning get_meaning();
+};
+
+/// Interface of a prober
+class ProberInterface {
+
+public:
+  /// Default constructor
+  ProberInterface() {}
+
+  /// Send a traceroute probe
+  /// \param addr Destination address
+  /// \param port Destination port
+  /// \param ttl Time to live
+  /// \param payload packet payload
+  /// \param timeout Timeout for this probe
+  /// \throws Exception on error
+  virtual void send_probe(std::string addr, int port, int ttl,
+                          std::string payload, double timeout) = 0;
+
+  /// Set callback called when result is available
+  virtual void on_result(std::function<void(ProbeResult)> cb) = 0;
+
+  /// Set callback called on timeout
+  virtual void on_timeout(std::function<void()> cb) = 0;
+
+  /// Set callback called when there is an error
+  virtual void on_error(std::function<void(std::runtime_error)> cb) = 0;
+
+  /// Default copy constructor
+  ProberInterface(ProberInterface&) = default;
+
+  /// Default assingment operator
+  ProberInterface& operator=(ProberInterface&) = default;
+
+  /// Default move constructor
+  ProberInterface(ProberInterface&&) = default;
+
+  /// Default move assignment operator
+  ProberInterface& operator=(ProberInterface&&) = default;
+
+  /// Default destructor
+  virtual ~ProberInterface();
+};
+
+/// Proxy for a prober implementation
+template <class Impl> class Prober : public ProberInterface {
+
+public:
+  /// Constructor
+  /// \param use_ipv4 Whether to use IPv4
+  /// \param port The port to bind
+  /// \param evbase Event base to use (optional)
+  /// \throws Exception on error
+  Prober(bool use_ipv4, int port,
+         event_base *evbase = ight_get_global_event_base()) {
+    impl_.reset(new Impl(use_ipv4, port, evbase));
+  }
+
+  virtual void send_probe(std::string addr, int port, int ttl,
+                          std::string payload, double timeout) final {
+    impl_->send_probe(addr, port, ttl, payload, timeout);
+  }
+
+  virtual void on_result(std::function<void(ProbeResult)> cb) final {
+    impl_->on_result(cb);
+  }
+
+  virtual void on_timeout(std::function<void()> cb) final {
+    impl_->on_timeout(cb);
+  }
+
+  virtual void on_error(std::function<void(std::runtime_error)> cb) final {
+    impl_->on_error(cb);
+  }
+
+private:
+  std::unique_ptr<Impl> impl_;
+};
+
+} // namespace traceroute
+} // namespace ight
+#endif

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -90,10 +90,7 @@ struct timeval *ight_timeval_init(struct timeval *tv, double delta) {
 int ight_storage_init(struct sockaddr_storage *storage, socklen_t *salen,
                       const char *family, const char *address,
                       const char *port) {
-    int _family, _port, result;
-    const char *errstr;
-
-    ight_info("utils:ight_storage_init - enter");
+    int _family;
 
     /* TODO: support also AF_INET, AF_INET6, ... */
     if (strcmp(family, "PF_INET") == 0) {
@@ -105,8 +102,31 @@ int ight_storage_init(struct sockaddr_storage *storage, socklen_t *salen,
         return (-1);
     }
 
+    return ight_storage_init(storage, salen, _family, address, port);
+}
+
+int ight_storage_init(struct sockaddr_storage *storage, socklen_t *salen,
+                      int _family, const char *address,
+                      const char *port) {
+    int _port;
+    const char *errstr;
+
     _port = (int)ight_strtonum(port, 0, 65535, &errstr);
     if (errstr != NULL) {
+        ight_warn("utils:ight_storage_init: invalid port");
+        return (-1);
+    }
+
+    return ight_storage_init(storage, salen, _family, address, _port);
+}
+
+int ight_storage_init(struct sockaddr_storage *storage, socklen_t *salen,
+                      int _family, const char *address, int _port) {
+    int result;
+
+    ight_info("utils:ight_storage_init - enter");
+
+    if (_port < 0 || _port > 65535) {
         ight_warn("utils:ight_storage_init: invalid port");
         return (-1);
     }
@@ -118,10 +138,14 @@ int ight_storage_init(struct sockaddr_storage *storage, socklen_t *salen,
         struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)storage;
         sin6->sin6_family = AF_INET6;
         sin6->sin6_port = htons(_port);
-        result = inet_pton(AF_INET6, address, &sin6->sin6_addr);
-        if (result != 1) {
-            ight_warn("utils:ight_storage_init: invalid addr");
-            return (-1);
+        if (address != NULL) {
+            result = inet_pton(AF_INET6, address, &sin6->sin6_addr);
+            if (result != 1) {
+                ight_warn("utils:ight_storage_init: invalid addr");
+                return (-1);
+            }
+        } else {
+            sin6->sin6_addr = in6addr_any;
         }
         *salen = sizeof(struct sockaddr_in6);
         break;
@@ -131,10 +155,14 @@ int ight_storage_init(struct sockaddr_storage *storage, socklen_t *salen,
         struct sockaddr_in *sin = (struct sockaddr_in *)storage;
         sin->sin_family = AF_INET;
         sin->sin_port = htons(_port);
-        result = inet_pton(AF_INET, address, &sin->sin_addr);
-        if (result != 1) {
-            ight_warn("utils:ight_storage_init: invalid addr");
-            return (-1);
+        if (address != NULL) {
+            result = inet_pton(AF_INET, address, &sin->sin_addr);
+            if (result != 1) {
+                ight_warn("utils:ight_storage_init: invalid addr");
+                return (-1);
+            }
+        } else {
+            sin->sin_addr.s_addr = INADDR_ANY;
         }
         *salen = sizeof(struct sockaddr_in);
         break;

--- a/src/include.am
+++ b/src/include.am
@@ -6,3 +6,4 @@ include src/net/include.am
 include src/ooni/include.am
 include src/protocols/include.am
 include src/report/include.am
+include src/traceroute/include.am

--- a/src/traceroute/android.cpp
+++ b/src/traceroute/android.cpp
@@ -1,0 +1,325 @@
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ *
+ * =========================================================================
+ *
+ * Portions Copyright (c) 2015, Adriano Faggiani, Enrico Gregori,
+ * Luciano Lenzini, Valerio Luconi
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/// Android implementation of prober
+
+// This is meant to run on Android but can run on all Linux systems
+#ifdef __linux__
+
+#include <ight/common/log.hpp>
+#include <ight/common/utils.hpp>
+#include <ight/traceroute/android.hpp>
+
+#include <arpa/inet.h>
+#include <linux/errqueue.h>
+
+#include <assert.h>
+#include <string.h>
+#include <unistd.h>
+
+namespace ight {
+namespace traceroute {
+
+AndroidProber::AndroidProber(bool a, int port, event_base *c)
+    : use_ipv4_(a), evbase_(c) {
+
+  sockaddr_storage ss;
+  socklen_t sslen;
+  int level_sock, opt_recverr, level_proto, opt_recvttl, family;
+  const int val = 1;
+
+  ight_debug("AndroidProber(%d, %d, %p) => %p", use_ipv4_, port,
+             (void *)evbase_, (void *)this);
+
+  if (use_ipv4_) {
+    level_sock = SOL_IP;
+    opt_recverr = IP_RECVERR;
+    level_proto = IPPROTO_IP;
+    opt_recvttl = IP_RECVTTL;
+    family = AF_INET;
+  } else {
+    level_sock = SOL_IPV6;
+    opt_recverr = IPV6_RECVERR;
+    level_proto = IPPROTO_IPV6;
+    opt_recvttl = IPV6_RECVHOPLIMIT;
+    family = AF_INET6;
+  }
+
+  sockfd_ = ight_socket_create(family, SOCK_DGRAM, 0);
+  if (sockfd_ == -1) {
+    cleanup();
+    throw std::runtime_error("Cannot create socket");
+  }
+
+  if (setsockopt(sockfd_, level_sock, opt_recverr, &val, sizeof(val)) != 0 ||
+      setsockopt(sockfd_, level_proto, opt_recvttl, &val, sizeof(val)) != 0 ||
+      setsockopt(sockfd_, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val)) != 0) {
+    cleanup();
+    throw std::runtime_error("Cannot set socket options");
+  }
+
+  if (ight_storage_init(&ss, &sslen, family, NULL, port) != 0) {
+    cleanup();
+    throw std::runtime_error("ight_storage_init() failed");
+  }
+  if (bind(sockfd_, (sockaddr *)&ss, sslen) != 0) {
+    cleanup();
+    throw std::runtime_error("bind() failed");
+  }
+
+  // Note: since here we use `this`, object cannot be copied/moved
+  if ((evp_ = event_new(evbase_, sockfd_, EV_READ, event_callback, this)) ==
+      NULL) {
+    cleanup();
+    throw std::runtime_error("event_new() failed");
+  }
+}
+
+void AndroidProber::send_probe(std::string addr, int port, int ttl,
+                               std::string payload, double timeout) {
+  int ipproto, ip_ttl, family;
+  sockaddr_storage ss;
+  socklen_t sslen;
+  timeval tv;
+
+  ight_debug("send_probe(%s, %d, %d, %lu)", addr.c_str(), port, ttl,
+             payload.length());
+
+  if (sockfd_ < 0)
+    throw std::runtime_error("Programmer error"); // already close()d
+
+  // Note: until we figure out exactly how to deal with overlapped
+  // probes enforce to traceroute hop by hop only
+  if (probe_pending_)
+    throw std::runtime_error("Another probe is pending");
+
+  if (use_ipv4_) {
+    ipproto = IPPROTO_IP;
+    ip_ttl = IP_TTL;
+    family = PF_INET;
+  } else {
+    ipproto = IPPROTO_IPV6;
+    ip_ttl = IPV6_UNICAST_HOPS;
+    family = PF_INET6;
+  }
+
+  if (setsockopt(sockfd_, ipproto, ip_ttl, &ttl, sizeof(ttl)) != 0)
+    throw std::runtime_error("setsockopt() failed");
+
+  if (ight_storage_init(&ss, &sslen, family, addr.c_str(), port) != 0)
+    throw std::runtime_error("ight_storage_init() failed");
+
+  if (clock_gettime(CLOCK_MONOTONIC, &start_time_) != 0)
+    throw std::runtime_error("clock_gettime() failed");
+
+  // Note: cast to ssize_t safe because payload length is bounded
+  // We may want however to increase the maximum accepted length
+  if (payload.length() > 512)
+    throw std::runtime_error("payload too large");
+  if (sendto(sockfd_, payload.data(), payload.length(), 0, (sockaddr *)&ss,
+             sslen) != (ssize_t)payload.length()) {
+    throw std::runtime_error("sendto() failed");
+  }
+
+  if (event_add(evp_, ight_timeval_init(&tv, timeout)) != 0)
+    throw std::runtime_error("event_add() failed");
+
+  probe_pending_ = true;
+}
+
+ProbeResult AndroidProber::on_socket_readable() {
+  int expected_level, expected_type_recverr, expected_type_ttl;
+  uint8_t expected_origin;
+  sock_extended_err *socket_error;
+  unsigned char buff[512];
+  char controlbuff[512];
+  ProbeResult r;
+  msghdr msg;
+  cmsghdr *cmsg;
+  iovec iov;
+  timespec arr_time;
+
+  ight_debug("on_socket_readable()");
+
+  if (!probe_pending_)
+    throw std::runtime_error("No probe is pending");
+  probe_pending_ = false;
+
+  r.is_ipv4 = use_ipv4_;
+
+  if (clock_gettime(CLOCK_MONOTONIC, &arr_time) != 0)
+    throw std::runtime_error("clock_gettime() failed");
+  r.rtt = calculate_rtt(arr_time, start_time_);
+  ight_debug("rtt = %lf", r.rtt);
+
+  memset(buff, 0, sizeof(buff));
+  iov.iov_base = buff;
+  iov.iov_len = sizeof(buff);
+  msg.msg_name = NULL;
+  msg.msg_namelen = 0;
+  msg.msg_iov = &iov;
+  msg.msg_iovlen = 1;
+  memset(controlbuff, 0, sizeof(controlbuff));
+  msg.msg_control = controlbuff;
+  msg.msg_controllen = sizeof(controlbuff);
+  msg.msg_flags = 0;
+  if ((r.recv_bytes = recvmsg(sockfd_, &msg, MSG_ERRQUEUE)) < 0)
+    throw std::runtime_error("recvmsg() failed");
+  ight_debug("recv_bytes = %lu", r.recv_bytes);
+
+  if (use_ipv4_) {
+    expected_level = SOL_IP;
+    expected_type_recverr = IP_RECVERR;
+    expected_type_ttl = IP_TTL;
+    expected_origin = SO_EE_ORIGIN_ICMP;
+  } else {
+    expected_level = IPPROTO_IPV6;
+    expected_type_recverr = IPV6_RECVERR;
+    expected_type_ttl = IPV6_HOPLIMIT;
+    expected_origin = SO_EE_ORIGIN_ICMP6;
+  }
+
+  for (cmsg = CMSG_FIRSTHDR(&msg); (cmsg); cmsg = CMSG_NXTHDR(&msg, cmsg)) {
+
+    if (cmsg->cmsg_level != expected_level) {
+      throw std::runtime_error("Unexpected socket level");
+    }
+    if (cmsg->cmsg_type != expected_type_recverr &&
+        cmsg->cmsg_type != expected_type_ttl) {
+      ight_warn("Received unexpected cmsg_type: %d", cmsg->cmsg_type);
+      continue;
+    }
+    if (cmsg->cmsg_type == expected_type_ttl) {
+      r.ttl = get_ttl(CMSG_DATA(cmsg));
+      ight_debug("ttl = %d", r.ttl);
+      continue;
+    }
+
+    // Be robust to refactoring
+    assert(cmsg->cmsg_type == expected_type_recverr);
+
+    socket_error = (sock_extended_err *)CMSG_DATA(cmsg);
+    if (socket_error->ee_origin != expected_origin) {
+      ight_warn("Received unexpected ee_type: %d", cmsg->cmsg_type);
+      continue;
+    }
+    r.icmp_type = socket_error->ee_type;
+    ight_debug("icmp_type = %d", r.icmp_type);
+    r.icmp_code = socket_error->ee_code;
+    ight_debug("icmp_code = %d", r.icmp_code);
+    r.interface_ip = get_source_addr(use_ipv4_, socket_error);
+    ight_debug("interface_ip = %s", r.interface_ip.c_str());
+  }
+
+  return r;
+}
+
+std::string AndroidProber::get_source_addr(bool use_ipv4,
+                                           sock_extended_err *se) {
+  // Note: I'm not annoyed by this function, if you are feel free to refactor
+  if (use_ipv4) {
+    char ip[INET_ADDRSTRLEN];
+    const sockaddr_in *sin = (const sockaddr_in *)SO_EE_OFFENDER(se);
+    if (inet_ntop(AF_INET, &sin->sin_addr, ip, INET_ADDRSTRLEN) == NULL)
+      throw std::runtime_error("inet_ntop failed");
+    return std::string(ip);
+  } else {
+    char ip[INET6_ADDRSTRLEN];
+    const sockaddr_in6 *sin6 = (const sockaddr_in6 *)SO_EE_OFFENDER(se);
+    if (inet_ntop(AF_INET6, &sin6->sin6_addr, ip, INET6_ADDRSTRLEN) == NULL)
+      throw std::runtime_error("inet_ntop failed");
+    return std::string(ip);
+  }
+}
+
+double AndroidProber::calculate_rtt(struct timespec end,
+                                    struct timespec start) {
+  const long NSEC_PER_SEC = 1000000000;
+  const long MICROSEC_PER_SEC = 1000000;
+  timespec temp;
+  if ((end.tv_nsec - start.tv_nsec) < 0) {
+    temp.tv_sec = end.tv_sec - start.tv_sec - 1;
+    temp.tv_nsec = NSEC_PER_SEC + end.tv_nsec - start.tv_nsec;
+  } else {
+    temp.tv_sec = end.tv_sec - start.tv_sec;
+    temp.tv_nsec = end.tv_nsec - start.tv_nsec;
+  }
+  long tmp = NSEC_PER_SEC * temp.tv_sec;
+  tmp += temp.tv_nsec;
+  double rtt_ms = (double)tmp / MICROSEC_PER_SEC;
+  if (rtt_ms < 0)
+    rtt_ms = -1.0; // XXX
+  return rtt_ms;
+}
+
+void AndroidProber::event_callback(int, short event, void *opaque) {
+  AndroidProber *prober = static_cast<AndroidProber *>(opaque);
+
+  ight_debug("event_callback(_, %d, %p)", event, opaque);
+
+  if ((event & EV_TIMEOUT) != 0) {
+    prober->on_timeout();
+    prober->timeout_cb_();
+
+  } else if ((event & EV_READ) != 0) {
+    ProbeResult result;
+    try {
+      result = prober->on_socket_readable();
+    } catch (std::runtime_error error) {
+      prober->error_cb_(error);
+      return;
+    }
+    prober->result_cb_(result);
+
+  } else
+    prober->error_cb_(std::runtime_error("Unexpected event error"));
+}
+
+void AndroidProber::cleanup() {
+  ight_debug("cleanup(): %p", (void *)this);
+  if (sockfd_ >= 0) {
+    ::close(sockfd_);
+    sockfd_ = -1;
+  }
+  // Note: we don't own evbase_
+  if (evp_ != nullptr) {
+    event_free(evp_);
+    evp_ = NULL;
+  }
+}
+
+} // namespace traceroute
+} // namespace ight
+
+#endif // __linux__

--- a/src/traceroute/include.am
+++ b/src/traceroute/include.am
@@ -1,0 +1,12 @@
+noinst_LTLIBRARIES += src/traceroute/libtraceroute.la
+
+src_traceroute_libtraceroute_la_SOURCES = \
+	src/traceroute/android.cpp \
+	src/traceroute/interface.cpp
+
+libight_la_LIBADD += src/traceroute/libtraceroute.la
+
+tracerouteincludedir = $(includedir)/ight/traceroute
+tracerouteinclude_HEADERS = \
+    include/ight/traceroute/android.hpp \
+    include/ight/traceroute/interface.hpp

--- a/src/traceroute/interface.cpp
+++ b/src/traceroute/interface.cpp
@@ -1,0 +1,91 @@
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ *
+ * =========================================================================
+ *
+ * Portions Copyright (c) 2015, Adriano Faggiani, Enrico Gregori,
+ * Luciano Lenzini, Valerio Luconi
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/// Implementation of traceroute interface
+
+#include <ight/common/log.hpp>
+#include <ight/traceroute/interface.hpp>
+
+#include <netinet/icmp6.h>
+#include <netinet/ip_icmp.h>
+
+namespace ight {
+namespace traceroute {
+
+struct ProbeResultMapping {
+  unsigned char type;
+  unsigned char code;
+  ProbeResultMeaning meaning;
+};
+
+#define PRM_ ProbeResultMeaning // For readability
+
+static ProbeResultMapping MAPPINGv4[] = {
+    {ICMP_TIME_EXCEEDED, ICMP_TIMXCEED_INTRANS, PRM_::TTL_EXCEEDED},
+    {ICMP_DEST_UNREACH, ICMP_UNREACH_PORT, PRM_::DEST_REACHED},
+    {ICMP_DEST_UNREACH, ICMP_UNREACH_PROTOCOL, PRM_::PROTO_NOT_IMPL},
+    {ICMP_DEST_UNREACH, ICMP_UNREACH_NET, PRM_::NO_ROUTE_TO_HOST},
+    {ICMP_DEST_UNREACH, ICMP_UNREACH_HOST, PRM_::ADDRESS_UNREACH},
+    {255, 255, PRM_::OTHER},
+};
+
+static ProbeResultMapping MAPPINGv6[] = {
+    {ICMP6_TIME_EXCEEDED, ICMP6_TIME_EXCEED_TRANSIT, PRM_::TTL_EXCEEDED},
+    {ICMP6_DST_UNREACH, ICMP6_DST_UNREACH_NOPORT, PRM_::DEST_REACHED},
+    {ICMP6_DST_UNREACH, ICMP6_DST_UNREACH_NOROUTE, PRM_::NO_ROUTE_TO_HOST},
+    {ICMP6_DST_UNREACH, ICMP6_DST_UNREACH_ADDR, PRM_::ADDRESS_UNREACH},
+    {ICMP6_DST_UNREACH, ICMP6_DST_UNREACH_ADMIN, PRM_::ADMIN_FILTER},
+    {255, 255, PRM_::OTHER},
+};
+
+#undef PRM_
+
+ProbeResultMeaning ProbeResult::get_meaning() {
+  for (auto m = is_ipv4 ? &MAPPINGv4[0] : &MAPPINGv6[0];
+       m->meaning != ProbeResultMeaning::OTHER; ++m) {
+    if (m->type == icmp_type && m->code == icmp_code) {
+      ight_debug("type %d code %d meaning %d", icmp_type, icmp_code,
+                 m->meaning);
+      return m->meaning;
+    }
+  }
+  ight_debug("type %d code %d meaning %d", icmp_type, icmp_code,
+             ProbeResultMeaning::OTHER);
+  return ProbeResultMeaning::OTHER;
+}
+
+ProberInterface::~ProberInterface() {}
+
+} // namespace traceroute
+} // namespace ight

--- a/test/include.am
+++ b/test/include.am
@@ -119,3 +119,9 @@ test_protocols_http_LDADD = libight.la
 test_protocols_http_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/protocols/http
 TESTS += test/protocols/http
+
+test_traceroute_android_SOURCES = test/traceroute/android.cpp
+test_traceroute_android_LDADD = libight.la
+test_traceroute_android_LDFLAGS = -lyaml-cpp
+check_PROGRAMS += test/traceroute/android
+TESTS += test/traceroute/android

--- a/test/traceroute/android.cpp
+++ b/test/traceroute/android.cpp
@@ -1,0 +1,58 @@
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+
+/// Tests Android traceroute prober
+
+// This is meant to run on Android but can run on all Linux systems
+#ifdef __linux__
+
+#define CATCH_CONFIG_MAIN
+#include "src/ext/Catch/single_include/catch.hpp"
+
+#include <ight/traceroute/android.hpp>
+
+#include <iostream>
+
+using namespace ight::traceroute;
+
+TEST_CASE("Typical IPv4 traceroute usage") {
+
+  std::string payload(256, '\0');
+  auto prober = Prober<AndroidProber>(true, 11829);
+  auto ttl = 1;
+
+  prober.on_result([&prober, &ttl, &payload](ProbeResult r) {
+    std::cout << ttl << " " << r.interface_ip << " " << r.rtt << " ms\n";
+    if (r.get_meaning() != ProbeResultMeaning::TTL_EXCEEDED || ttl >= 64) {
+      ight_break_loop();
+      return;
+    }
+    prober.send_probe("8.8.8.8", 33434, ++ttl, payload, 1.0);
+  });
+
+  prober.on_timeout([&prober, &ttl, &payload]() {
+    std::cout << ttl << " *\n";
+    if (ttl >= 64) {
+      ight_break_loop();
+      return;
+    }
+    prober.send_probe("8.8.8.8", 33434, ++ttl, payload, 1.0);
+  });
+
+  prober.on_error([&prober, &ttl, &payload](std::runtime_error err) {
+    std::cout << ttl << " error: " << err.what() << "\n";
+    if (ttl >= 64) {
+      ight_break_loop();
+      return;
+    }
+    prober.send_probe("8.8.8.8", 33434, ++ttl, payload, 1.0);
+  });
+
+  prober.send_probe("8.8.8.8", 33434, ttl, payload, 1.0);
+  ight_loop();
+}
+#endif


### PR DESCRIPTION
This is same as #117 except that I rebased the branch and squashed commits. I'd rather used #117 but apparently I cannot easily reopen it since I rebased.

---

This code was contributed by developers of Portolan, a network measurement tool developed at University of Pisa.

Many many thanks!

I started merging this code to libight during the Tor winter dev meeting in Valencia, after which I was able to compile it.

Then I worked on this together with @ValerioLuconi during a two day hackfest held in Pisa (27-28 Apr).

Finally I also worked on this on May 21, at Nexa.

This code compiles and runs on Linux, an early version of it was tested it both using IPv6 (at CNR), this version only on IPv4.

The original history of this contribution to libight counted 60+ commits that I have squashed to tidy things up.